### PR TITLE
fix: change restlet maven repo to working repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-resolvers += "Twitter Repository" at "http://maven.twttr.com/"
+resolvers += "Twitter Repository" at "https://maven.twttr.com/"
 
-resolvers += "Sonatype-public" at "http://oss.sonatype.org/content/groups/public"
+resolvers += "Sonatype-public" at "https://oss.sonatype.org/content/groups/public"
 
-resolvers += "Restlet repository" at "http://maven.restlet.org"
+resolvers += "Restlet repository" at "https://maven.restlet.talend.com"
 
 Keys.fork in Test := true
 


### PR DESCRIPTION
The old repo was no longer working.  This one does though.

Props to @damanyang for helping me figure this one out.